### PR TITLE
npm i --save-dev @types/next por error en llamado a componentes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@types/next": "^9.0.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -447,6 +448,16 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/next": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/next/-/next-9.0.0.tgz",
+      "integrity": "sha512-gnBXM8rP1mnCgT1uE2z8SnpFTKRWReJlhbZLZkOLq/CH1ifvTNwjIVtXvsywTy1dwVklf+y/MB0Eh6FOa94yrg==",
+      "deprecated": "This is a stub types definition. next provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "next": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.14.1",

--- a/package.json
+++ b/package.json
@@ -9,18 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.3",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.3"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@types/next": "^9.0.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.3",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.3"
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
 (JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.ts(7026)) se debe a que TypeScript no puede encontrar la definición de los elementos JSX, lo cual usualmente se debe a la configuración del proyecto o a la falta de algunos tipos necesarios para TypeScript.

Se ejecuta:` npm install --save-dev @types/react @types/react-dom`
