### PR TITLE
se arreglan las variables de entorno al instanciarlas

### DIFF
--- a/firebase/firebaseConfig.ts
+++ b/firebase/firebaseConfig.ts
@@ -4,13 +4,13 @@ import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
-  apiKey: process.env.API_KEY,
-  authDomain: process.env.AUTH_DOMAIN,
-  projectId: process.env.PROJECT_ID,
-  storageBucket: process.env.STORAGE_BUCKET,
-  messagingSenderId: process.env.MESSAGING_SENDER_ID,
-  appId: process.env.APP_ID,
-  measurementId: process.env.MEASUREMENT_ID,
+  apiKey: process.env.NEXT_PUBLIC_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_MEASUREMENT_ID,
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
- En Next.js, las variables de entorno que deben ser accesibles tanto en el servidor como en el cliente necesitan estar prefijadas con NEXT_PUBLIC_. Este prefijo permite que Next.js distinga entre variables de entorno que son seguras para ser expuestas al navegador y aquellas que no lo son.

**Razones para usar NEXT_PUBLIC_**

Seguridad:

**Variables sin prefijo:** Las variables de entorno que no tienen el prefijo NEXT_PUBLIC_ están destinadas a ser usadas solo en el servidor. Esto incluye variables sensibles como claves API, secretos de base de datos, y otras configuraciones que no deben ser accesibles desde el cliente.
**Variables con NEXT_PUBLIC_:** Estas variables están diseñadas para ser accesibles tanto en el servidor como en el cliente. Next.js hace que estas variables estén disponibles en el navegador, permitiendo su uso en componentes de React y otros scripts del cliente.
Claridad y Mantenimiento:

Al usar el prefijo NEXT_PUBLIC_, queda claro qué variables de entorno son seguras para ser usadas en el cliente. Esto reduce el riesgo de exponer accidentalmente información sensible al navegador.
Facilita la gestión y revisión del código, ya que es evidente cuáles variables están destinadas a ser públicas.